### PR TITLE
Fix README.md to run on ubuntu-latest, add install sbt steps

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,6 +12,8 @@ jobs:
         with:
           distribution: 'adopt'
           java-version: '21'
+      - name: Install sbt
+        uses: sbt/setup-sbt@v1
       - name: Run tests
         run: sbt coverage test coverageReport
       - uses: codecov/codecov-action@v4

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ jobs:
         with:
           distribution: 'adopt'
           java-version: '21'
+      - name: Install sbt
+        uses: sbt/setup-sbt@v1
       - name: Run tests
         run: sbt coverage test coverageReport
       - uses: codecov/codecov-action@v4


### PR DESCRIPTION
see: https://github.com/scala-steward-org/scala-steward-action/pull/644

sbt was removed from the ubuntu-latest , so we should add step to install it before running.